### PR TITLE
add MEEDS weekly cron job

### DIFF
--- a/nutch/scripts/transfer-segments.sh
+++ b/nutch/scripts/transfer-segments.sh
@@ -40,5 +40,14 @@ find /usr/local/memex/wrangler_crawl/production -type d -name "segments" > curre
 ./wrangler_batch_dump.sh current_scp_wrangler_segments.txt
 mv /usr/local/memex/wrangler_crawl/production/* /usr/local/memex/wrangler_crawl/archive/
 
-# TODO: find delta updates docIDs of fileDumper
-# TODO: fire off parser-indexer
+# Find delta updates/docIDs of fileDumper
+cd runtime/local/logs
+today=$(date +"%m-%d-%y")
+updates=$today"DocIDs.txt"
+cat hadoop.log | grep Writing | cut -d" " -f 8 | cut -d"[" -f 2 | cut -d"]" -f 1 > /usr/local/memex/wrangler_crawl/deltaUpdates/$updates
+
+# Fire off parser-indexer
+source ~/jdk8.sh
+cd ~/imagecat/tmp/parser-indexer
+java -jar parser-indexer/target/nutch-tika-solr-1.0-SNAPSHOT.jar postdump -list /usr/local/memex/wrangler_crawl/deltaUpdates/$updates -solr http://localhost:8983/solr/imagecatdev -timeout 70000
+echo "JOB COMPLETE"


### PR DESCRIPTION
@chrismattmann This PR implements the **Complete Weekly MEEDs Life Cycle from scp to Solr Ingestion**

Since this is a weekly Cron job, hadoop.log on imagecat.d.o will contain the correct FileDumped Paths/Delta Updates associated with the scp'ed segments in this job.

FYI @karanjeets @thammegowda 

Thanks everyone!
